### PR TITLE
🐞 fix: Fix not able to add anywhere rule due to invalid request

### DIFF
--- a/src/lib/vultr/VultrAPI.ts
+++ b/src/lib/vultr/VultrAPI.ts
@@ -87,7 +87,7 @@ export class VultrAPI implements IVultrAPI {
                     // Parameters for the request are required, but none were passed in
                     throw new RequestError(`Missing parameter: ${parameter}`);
                 }
-                if (userParameter || userParameter === "") {
+                if (userParameter !== undefined) {
                     if (
                         endpointParameter.type === "array" &&
                         !Array.isArray(userParameter)


### PR DESCRIPTION
The reason of this is due to the subnet_size of 0 treated as falsy condition during validating request parameters and thus gets ignored somethow.