### PR TITLE
chore(.gitignore): replace vscode settings.json with example config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,7 +218,7 @@ sketch
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
+# !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
@@ -259,3 +259,6 @@ bunfig.toml
 *.code-workspace
 
 build-info.json
+
+.vscode/settings.json
+!.vscode/settings.example.json

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,7 +1,7 @@
 {
     "tailwindCSS.experimental.configFile": "./frontend/libs/tailwind/src/tailwind.css",
     "tailwindCSS.classFunctions": ["cn"],
-    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "typescript.tsdk": "node_modules/typescript/lib",
     "search.followSymlinks": false,
     // change this to do conditional build check
     // examples:

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,4 +1,6 @@
 {
+    // VSCode settings template. Copy recommended settings to your local .vscode/settings.json.
+    // Do not commit personal overrides—this file should remain a shared reference.
     "tailwindCSS.experimental.configFile": "./frontend/libs/tailwind/src/tailwind.css",
     "tailwindCSS.classFunctions": ["cn"],
     "typescript.tsdk": "node_modules/typescript/lib",

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,0 +1,16 @@
+{
+    "tailwindCSS.experimental.configFile": "./frontend/libs/tailwind/src/tailwind.css",
+    "tailwindCSS.classFunctions": ["cn"],
+    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "search.followSymlinks": false,
+    // change this to do conditional build check
+    // examples:
+    //  windows ->  "x86_64-pc-windows-msvc"
+    //  macos   ->  "aarch64-apple-darwin
+    //  linux   ->  "x86_64-unknown-linux-gnu"
+    //  android ->  "aarch64-linux-android"
+    "rust-analyzer.cargo.target": null,
+    "files.associations": {
+        "*.json": "jsonc"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "tailwindCSS.experimental.configFile": "./frontend/libs/tailwind/src/tailwind.css"
-}


### PR DESCRIPTION
- Comment out the negation of .vscode/settings.json in the ignore list
- Add .vscode/settings.json to the ignore list
- Exclude .vscode/settings.example.json from being ignored

This change ensures that the actual settings file is ignored while providing an example settings file that can be used as a template. Also includes comprehensive default settings for Tailwind CSS, TypeScript, and other recommended VS Code configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an example editor settings file to help standardize local development setups.
  * Updated repository ignore rules to exclude personal editor settings from version control while keeping the example template tracked.
  * Removed an editor-specific experimental override for the Tailwind configuration so the project default configuration is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->